### PR TITLE
Allow symbol key and weight funcs, and clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Add this line to your application's Gemfile:
 
 And then execute:
 
-    $ bundle
+    bundle
 
 Or install it yourself as:
 
-    $ gem install pickup
+    gem install pickup
 
 ## Usage
 
@@ -31,6 +31,7 @@ pond = {
   "minnow" => 20
 }
 ```
+
 Values are a chance (probability) to get this fish.
 
 So we should create our pickup.
@@ -40,6 +41,7 @@ pickup = Pickup.new(pond)
 pickup.pick(3)
 #=> [ "gudgeon", "minnow", "minnow" ]
 ```
+
 Look, we've just catched few minnows! To get selmon we need some more tries ;)
 
 ### Custom distribution function
@@ -51,6 +53,7 @@ pickup = Pickup.new(pond){ |v| v**2 }
 pickup.pick(3)
 #=> ["carp", "selmon", "crucian"]
 ```
+
 Wow, good catch!
 
 Also you can change our "function" on the fly. Let's make square function:
@@ -59,6 +62,7 @@ Also you can change our "function" on the fly. Let's make square function:
 pickup = Pickup.new(pond)
 pickup.pick_func = Proc.new{ |v| v**2 }
 ```
+
 Or you can pass a block as a probability function wich will be applicable only to current operation
 
 ```ruby
@@ -109,19 +113,22 @@ We can use more complex collections by defining our own key and weight selectors
 require "ostruct"
 
 pond_ostruct = [
-  OpenStruct.new(key: "sel", name: "selmon", weight: 1),
-  OpenStruct.new(key: "car", name: "carp", weight: 4),
-  OpenStruct.new(key: "cru", name: "crucian", weight: 3),
-  OpenStruct.new(key: "her", name: "herring", weight: 6),
+  OpenStruct.new(key: "sel", name: "selmon",   weight: 1),
+  OpenStruct.new(key: "car", name: "carp",     weight: 4),
+  OpenStruct.new(key: "cru", name: "crucian",  weight: 3),
+  OpenStruct.new(key: "her", name: "herring",  weight: 6),
   OpenStruct.new(key: "stu", name: "sturgeon", weight: 8),
-  OpenStruct.new(key: "gud", name: "gudgeon", weight: 10),
-  OpenStruct.new(key: "min", name: "minnow", weight: 20)
+  OpenStruct.new(key: "gud", name: "gudgeon",  weight: 10),
+  OpenStruct.new(key: "min", name: "minnow",   weight: 20)
 ]
 
 key_func = Proc.new{ |item| item.key }
 weight_func = Proc.new{ |item| item.weight }
-
 pickup = Pickup.new(pond_ostruct, key_func: key_func, weight_func: weight_func)
+
+# Symbol values for funcs will be converted into Procs:
+pickup = Pickup.new(pond_ostruct, key_func: :key, weight_func: :weight)
+
 pickup.pick
 #=> "gud"
 

--- a/lib/pickup.rb
+++ b/lib/pickup.rb
@@ -8,14 +8,14 @@ class Pickup
     @list = list
     @uniq = opts[:uniq] || false
     @pick_func = block if block_given?
-    @key_func = opts[:key_func]
-    @weight_func = opts[:weight_func]
+    @key_func = Pickup.func_opt(opts[:key_func])
+    @weight_func = Pickup.func_opt(opts[:weight_func])
   end
 
   def pick(count=1, opts={}, &block)
     func = block || pick_func
-    key_func = opts[:key_func] || @key_func
-    weight_func = opts[:weight_func] || @weight_func
+    key_func = Pickup.func_opt(opts[:key_func]) || @key_func
+    weight_func = Pickup.func_opt(opts[:weight_func]) || @weight_func
     mlist = MappedList.new(list, func, uniq: uniq, key_func: key_func, weight_func: weight_func)
     result = mlist.random(count)
     count == 1 ? result.first : result
@@ -29,6 +29,10 @@ class Pickup
     end
   end
 
+  def self.func_opt(opt)
+    opt.is_a?(Symbol) ? opt.to_proc : opt
+  end
+
   class CircleIterator
     attr_reader :func, :obj, :max, :key_func, :weight_func
 
@@ -36,8 +40,8 @@ class Pickup
       @obj = obj.dup
       @func = func
       @max = max
-      @key_func = opts[:key_func] || key_func
-      @weight_func = opts[:weight_func] || weight_func
+      @key_func = Pickup.func_opt(opts[:key_func]) || key_func
+      @weight_func = Pickup.func_opt(opts[:weight_func]) || weight_func
     end
 
     def key_func
@@ -79,8 +83,8 @@ class Pickup
 
     def initialize(list, func, opts=nil)
       if Hash === opts
-        @key_func = opts[:key_func]
-        @weight_func = opts[:weight_func] || weight_func
+        @key_func = Pickup.func_opt(opts[:key_func])
+        @weight_func = Pickup.func_opt(opts[:weight_func]) || weight_func
         @uniq = opts[:uniq] || false
       else
         if !!opts == opts

--- a/lib/pickup/circle_iterator.rb
+++ b/lib/pickup/circle_iterator.rb
@@ -1,0 +1,40 @@
+class Pickup
+  class CircleIterator
+    attr_reader :func, :obj, :max
+
+    def initialize(obj, func, max, opts = {})
+      @obj = obj.dup
+      @func = func
+      @max = max
+      @key_func = Pickup.func_opt(opts[:key_func]) || key_func
+      @weight_func = Pickup.func_opt(opts[:weight_func]) || weight_func
+    end
+
+    def key_func
+      @key_func ||= proc { |item| item[0] }
+    end
+
+    def weight_func
+      @weight_func ||= proc { |item| item[1] }
+    end
+
+    def each
+      until obj.empty?
+        start = 0
+
+        obj.each do |item|
+          key = key_func.call(item)
+          weight = weight_func.call(item)
+
+          val = func.call(weight)
+          start += val
+
+          if yield([key, start, max])
+            obj.delete(key)
+            @max -= val
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pickup/mapped_list.rb
+++ b/lib/pickup/mapped_list.rb
@@ -1,0 +1,74 @@
+class Pickup
+  class MappedList
+    attr_reader :list, :func, :uniq
+
+    BOOLEAN_DEPRECATION ||= '[DEPRECATED] Passing uniq as a boolean to ' \
+    "MappedList's initialize method is deprecated. Please use the opts hash " \
+    'instead.'.freeze
+
+    def initialize(list, func, opts = nil)
+      if opts.is_a?(Hash)
+        @key_func = Pickup.func_opt(opts[:key_func]) || key_func
+        @weight_func = Pickup.func_opt(opts[:weight_func]) || weight_func
+        @uniq = opts[:uniq] || false
+      else
+        # If opts is explicitly provided as a boolean, show the warning.
+        warn BOOLEAN_DEPRECATION if [true, false].include?(opts)
+
+        @uniq = opts || false
+      end
+
+      @func = func
+      @list = list
+      @current_state = 0
+    end
+
+    def key_func
+      @key_func ||= proc { |item| item[0] }
+    end
+
+    def weight_func
+      @weight_func ||= proc { |item| item[1] }
+    end
+
+    def max
+      @max ||= list.sum { |item| func.call(weight_func.call(item)) }
+    end
+
+    def each(*)
+      CircleIterator.new(
+        @list, func, max, key_func: key_func, weight_func: weight_func
+      ).each do |item|
+        if uniq
+          true if yield item
+        else
+          nil while yield(item)
+        end
+      end
+    end
+
+    def random(count)
+      if uniq && list.size < count
+        raise 'List is shorter than count of items you want to get'
+      end
+
+      nums = count.times.map { rand(max) }.sort
+      return [] if max.zero?
+
+      get_random_items(nums)
+    end
+
+    def get_random_items(nums)
+      current_num = nums.shift
+      items = []
+      each do |item, counter, mx|
+        break unless current_num
+        next unless counter % (mx + 1) > current_num % mx
+
+        items << item
+        current_num = nums.shift
+      end
+      items
+    end
+  end
+end

--- a/lib/pickup/version.rb
+++ b/lib/pickup/version.rb
@@ -1,3 +1,3 @@
 class Pickup
-  VERSION = "0.0.11"
+  VERSION = "0.0.12"
 end


### PR DESCRIPTION
## Changes

- Allows passing a symbol for a method name into `:key_func` and `:weight_func`, to avoid having to generate a proc beforehand
- Bump version to `0.0.12`

## Cleanup

- Pulls the child classes into separate files, while maintaining class nesting.
- Simplifies some begin blocks
- Some general cosmetic cleanup

## Specs

- All passing locally